### PR TITLE
fix: remove Node 16 from deployment pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
     steps:
       - name: Code Checkout 🛎️
         uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        node-version: [ 16.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
     steps:
       - name: Code Checkout 🛎️
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monguito",
-  "version": "2.10.1",
-  "description": "Small generic and polymorphic MongoDB repository implementation for Node.js apps.",
+  "version": "2.11.0",
+  "description": "MongoDB Abstract Repository implementation for Node.js",
   "author": {
     "name": "Josu Martinez",
     "email": "josu.martinez@gmail.com"


### PR DESCRIPTION
## What is the purpose of this pull request? 
Put an "X" next to item:

[x] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

## What changes did you make? 
Removed Node 16 from GH Actions deployment pipeline since `lint-stage` dev dependency v15.x requires Node version >=18.12. Also update NPM package description. Finally, performed new minor version bump.

## Which issue (if any) does this pull request address?

## Is there anything you'd like reviewers to focus on?
