### PR TITLE
New entity storage exception type fix, extendSchema overload, and further API doc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
-import { MongooseRepository } from './mongoose.repository';
-import { Repository } from './repository';
+import {
+  Constructor,
+  ConstructorMap,
+  MongooseRepository,
+} from './mongoose.repository';
+import { PartialEntityWithId, Repository } from './repository';
 import { Auditable, AuditableClass, isAuditable } from './util/audit';
 import { Entity } from './util/entity';
 import {
@@ -14,9 +18,12 @@ export {
   AuditableClass,
   AuditableSchema,
   BaseSchema,
+  Constructor,
+  ConstructorMap,
   Entity,
   IllegalArgumentException,
   MongooseRepository,
+  PartialEntityWithId,
   Repository,
   UndefinedConstructorException,
   ValidationException,

--- a/src/util/audit.ts
+++ b/src/util/audit.ts
@@ -19,6 +19,10 @@ export abstract class AuditableClass implements Auditable {
   readonly updatedBy?: string;
   readonly version?: number;
 
+  /**
+   * Creates an auditable persistable domain object instance.
+   * @param {Auditable} entity the entity to create the auditable persistable domain object from.
+   */
   constructor(entity: Auditable) {
     this.createdAt = entity.createdAt;
     this.createdBy = entity.createdBy;
@@ -31,8 +35,8 @@ export abstract class AuditableClass implements Auditable {
 /**
  * Determines whether a given domain object is {@link Auditable}.
  *
- * @param entity the entity to evaluate.
- * @returns true if the given entity is auditable, false otherwise.
+ * @param {any} entity the entity to evaluate.
+ * @returns {boolean} `true` if the given entity is auditable, `false` otherwise.
  */
 export const isAuditable = (entity: any): entity is Auditable =>
   entity &&

--- a/src/util/exceptions.ts
+++ b/src/util/exceptions.ts
@@ -11,6 +11,11 @@ abstract class Exception extends Error {
  * Models a client provided illegal argument exception.
  */
 export class IllegalArgumentException extends Exception {
+  /**
+   * Creates an `IllegalArgumentException`, optionally wrapping an error.
+   * @param {string} message the message of the exception.
+   * @param {Error=} error (optional) the wrapped error.
+   */
   constructor(message: string, error?: Error) {
     super(message, error);
   }
@@ -20,6 +25,11 @@ export class IllegalArgumentException extends Exception {
  * Models an undefined persistable domain object constructor exception.
  */
 export class UndefinedConstructorException extends Exception {
+  /**
+   * Creates an `UndefinedConstructorException`, optionally wrapping an error.
+   * @param {string} message the message of the exception.
+   * @param {Error=} error (optional) the wrapped error.
+   */
   constructor(message: string, error?: Error) {
     super(message, error);
   }
@@ -29,6 +39,11 @@ export class UndefinedConstructorException extends Exception {
  * Models a persistable domain object schema validation rule violation exception.
  */
 export class ValidationException extends Exception {
+  /**
+   * Creates an `ValidationException`, optionally wrapping an error.
+   * @param {string} message the message of the exception.
+   * @param {Error=} error (optional) the wrapped error.
+   */
   constructor(message: string, error?: Error) {
     super(message, error);
   }

--- a/src/util/search-options.ts
+++ b/src/util/search-options.ts
@@ -2,7 +2,6 @@ import { IllegalArgumentException } from './exceptions';
 
 /**
  * Page specification utility class.
- *
  * @property {number} pageNumber the page number to retrieve.
  * @property {number} offset the number of entities composing the result.
  */
@@ -10,6 +9,11 @@ export class Pageable {
   readonly pageNumber: number;
   readonly offset: number;
 
+  /**
+   * Creates a pageable instance.
+   * @param {Pageable} pageable the instance to create the pageable from.
+   * @throws {IllegalArgumentException} if the given instance does not specify a page number and an offset.
+   */
   constructor(pageable: Pageable) {
     if (!pageable.pageNumber) {
       throw new IllegalArgumentException(
@@ -19,7 +23,6 @@ export class Pageable {
     if (!pageable.offset) {
       throw new IllegalArgumentException('A value for the offset is missing');
     }
-
     this.pageNumber = pageable.pageNumber;
     this.offset = pageable.offset;
   }
@@ -27,10 +30,9 @@ export class Pageable {
 
 /**
  * Specifies some options to narrow down a search operation.
- *
- * @property {any} filters (optional) a MongoDB entity field-based query to filter results.
- * @property {any} sortBy (optional) a MongoDB sort criteria to return results in some sorted order.
- * @property {Pageable} pageable (optional) page data (i.e., page number and offset) required to return a particular set of results.
+ * @property {any=} filters (optional) a MongoDB entity field-based query to filter results.
+ * @property {any=} sortBy (optional) a MongoDB sort criteria to return results in some sorted order.
+ * @property {Pageable=} pageable (optional) page data (i.e., page number and offset) required to return a particular set of results.
  */
 export type SearchOptions = {
   filters?: any;

--- a/test/repository/book.schema.ts
+++ b/test/repository/book.schema.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'mongoose';
 import { BaseSchema, extendSchema } from '../../src';
-import { Book, PaperBook } from '../domain/book';
+import { AudioBook, Book, PaperBook } from '../domain/book';
 
 export const BookSchema: Schema<Book> = extendSchema(BaseSchema, {
   title: { type: String, required: true },
@@ -8,14 +8,17 @@ export const BookSchema: Schema<Book> = extendSchema(BaseSchema, {
   isbn: { type: String, required: true, unique: true },
 });
 
-export const PaperBookSchema: Schema<PaperBook> = extendSchema<Book, PaperBook>(
+export const PaperBookSchema: Schema<PaperBook> = extendSchema(
   BookSchema,
-  {
+  new Schema<PaperBook>({
     edition: { type: Number, required: true, min: 1 },
-  },
+  }),
 );
 
-export const AudioBookSchema = extendSchema(BookSchema, {
-  hostingPlatforms: { type: [{ type: String }], required: true },
-  format: { type: String, required: false },
-});
+export const AudioBookSchema: Schema<AudioBook> = extendSchema<Book, AudioBook>(
+  BookSchema,
+  {
+    hostingPlatforms: { type: [{ type: String }], required: true },
+    format: { type: String, required: false },
+  },
+);


### PR DESCRIPTION
## What is the purpose of this pull request? 
Put an "X" next to item:

[x] Documentation update
[x] Bug fix
[x] New feature
[ ] Other, please explain:

## What changes did you make? 
- Fixed exception type when trying to store a new entity that specifies a duplicated `id` to be a `ValidationException`
- Added `extendSchema` overload to enable clients to pass a schema as the extension parameter
- Added further JSDoc to `monguito` API

## Which issue (if any) does this pull request address?
#163 - inspired new `extendSchema` overload

## Is there anything you'd like reviewers to focus on?
