### PR TITLE
feat: add atomic version of update operation

### DIFF
--- a/examples/nestjs-mongoose-book-manager/src/book.controller.ts
+++ b/examples/nestjs-mongoose-book-manager/src/book.controller.ts
@@ -59,10 +59,10 @@ export class BookController {
   @Patch(':id')
   async update(
     @Param('id') id: string,
-    @Body() book: PartialBook,
+    @Body() book: Partial<Book>,
   ): Promise<Book> {
-    book.id = id;
-    return this.save(book);
+    const bookToUpdate = { ...book, id };
+    return this.save(bookToUpdate);
   }
 
   @Post('/all')

--- a/examples/nestjs-mongoose-book-manager/test/book.controller.test.ts
+++ b/examples/nestjs-mongoose-book-manager/test/book.controller.test.ts
@@ -101,52 +101,6 @@ describe('Given the book manager controller', () => {
     });
   });
 
-  describe('when updating a book', () => {
-    describe('that is invalid', () => {
-      it('returns a bad request HTTP status code', () => {
-        const paperBookToUpdate = {
-          edition: 0,
-        };
-        return request(bookManager.getHttpServer())
-          .patch(`/books/${storedPaperBook.id}`)
-          .send(paperBookToUpdate)
-          .expect(HttpStatus.BAD_REQUEST);
-      });
-    });
-
-    describe('that is not stored', () => {
-      it('returns a bad request HTTP status code', () => {
-        const paperBookToUpdate = {
-          edition: 4,
-        };
-        return request(bookManager.getHttpServer())
-          .patch('/books/000000000000000000000000')
-          .send(paperBookToUpdate)
-          .expect(HttpStatus.BAD_REQUEST);
-      });
-    });
-
-    describe('that is stored', () => {
-      it('returns the updated book', () => {
-        const paperBookToUpdate = {
-          edition: 4,
-        };
-        return request(bookManager.getHttpServer())
-          .patch(`/books/${storedPaperBook.id}`)
-          .send(paperBookToUpdate)
-          .expect(HttpStatus.OK)
-          .expect((response) => {
-            const updatedPaperBook = response.body as PaperBook;
-            expect(updatedPaperBook).toMatchObject(paperBookToUpdate);
-            expect(updatedPaperBook.title).toBe(storedPaperBook.title);
-            expect(updatedPaperBook.description).toBe(
-              storedPaperBook.description,
-            );
-          });
-      });
-    });
-  });
-
   describe('when deleting a book', () => {
     describe('that is not stored', () => {
       it('returns false', () => {

--- a/examples/nestjs-mongoose-book-manager/test/book.transactional-controller.test.ts
+++ b/examples/nestjs-mongoose-book-manager/test/book.transactional-controller.test.ts
@@ -46,6 +46,52 @@ describe('Given the book manager controller', () => {
     });
   });
 
+  describe('when updating a book', () => {
+    describe('that is invalid', () => {
+      it('returns a bad request HTTP status code', () => {
+        const paperBookToUpdate = {
+          edition: 0,
+        };
+        return request(bookManager.getHttpServer())
+          .patch(`/books/${storedPaperBook.id}`)
+          .send(paperBookToUpdate)
+          .expect(HttpStatus.BAD_REQUEST);
+      });
+    });
+
+    describe('that is not stored', () => {
+      it('returns a bad request HTTP status code', () => {
+        const paperBookToUpdate = {
+          edition: 4,
+        };
+        return request(bookManager.getHttpServer())
+          .patch('/books/000000000000000000000000')
+          .send(paperBookToUpdate)
+          .expect(HttpStatus.BAD_REQUEST);
+      });
+    });
+
+    describe('that is stored', () => {
+      it('returns the updated book', () => {
+        const paperBookToUpdate = {
+          edition: 4,
+        };
+        return request(bookManager.getHttpServer())
+          .patch(`/books/${storedPaperBook.id}`)
+          .send(paperBookToUpdate)
+          .expect(HttpStatus.OK)
+          .expect((response) => {
+            const updatedPaperBook = response.body as PaperBook;
+            expect(updatedPaperBook).toMatchObject(paperBookToUpdate);
+            expect(updatedPaperBook.title).toBe(storedPaperBook.title);
+            expect(updatedPaperBook.description).toBe(
+              storedPaperBook.description,
+            );
+          });
+      });
+    });
+  });
+
   describe('when saving a list of books', () => {
     describe('that includes an invalid book', () => {
       it('returns a bad request HTTP status code', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monguito",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "MongoDB Abstract Repository implementation for Node.js",
   "author": {
     "name": "Josu Martinez",

--- a/src/mongoose.repository.ts
+++ b/src/mongoose.repository.ts
@@ -224,10 +224,19 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
     return entityModel;
   }
 
+  /**
+   * Inserts an entity.
+   * @param {S} entity the entity to insert.
+   * @param {SaveOptions=} options (optional) insert operation options.
+   * @returns {Promise<S>} the inserted entity.
+   * @throws {IllegalArgumentException} if the given entity is `undefined` or `null`.
+   */
   protected async insert<S extends T>(
     entity: S,
     options?: SaveOptions,
   ): Promise<S> {
+    if (!entity)
+      throw new IllegalArgumentException('The given entity must be valid');
     const entityClassName = entity['constructor']['name'];
     if (!this.typeMap.has(entityClassName)) {
       throw new IllegalArgumentException(
@@ -262,10 +271,19 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
     return document;
   }
 
+  /**
+   * Updates an entity.
+   * @param {S} entity the entity to update.
+   * @param {SaveOptions=} options (optional) update operation options.
+   * @returns {Promise<S>} the updated entity.
+   * @throws {IllegalArgumentException} if the given entity is `undefined` or `null` or specifies an `id` not matching any existing entity.
+   */
   protected async update<S extends T>(
     entity: PartialEntityWithId<S>,
     options?: SaveOptions,
   ): Promise<S> {
+    if (!entity)
+      throw new IllegalArgumentException('The given entity must be valid');
     const document = await this.entityModel
       .findById<HydratedDocument<S>>(entity.id)
       .session(options?.session ?? null);

--- a/src/mongoose.transactional-repository.ts
+++ b/src/mongoose.transactional-repository.ts
@@ -67,9 +67,10 @@ export abstract class MongooseTransactionalRepository<
     entity: PartialEntityWithId<S>,
     options?: SaveOptions,
   ): Promise<S> {
+    const updateOperation = super.update.bind(this);
     return await runInTransaction(
       async (session: ClientSession) =>
-        await super.update(entity, {
+        await updateOperation(entity, {
           userId: options?.userId,
           session: options?.session ?? session,
         }),

--- a/src/mongoose.transactional-repository.ts
+++ b/src/mongoose.transactional-repository.ts
@@ -4,7 +4,11 @@ import { PartialEntityWithId } from './repository';
 import { TransactionalRepository } from './transactional-repository';
 import { Entity } from './util/entity';
 import { IllegalArgumentException } from './util/exceptions';
-import { DeleteAllOptions, SaveAllOptions } from './util/operation-options';
+import {
+  DeleteAllOptions,
+  SaveAllOptions,
+  SaveOptions,
+} from './util/operation-options';
 import { runInTransaction } from './util/transaction';
 
 /**
@@ -54,6 +58,21 @@ export abstract class MongooseTransactionalRepository<
       async (session: ClientSession) =>
         (await this.entityModel.deleteMany(options?.filters, { session }))
           .deletedCount,
+      { connection: this.connection },
+    );
+  }
+
+  /** @inheritdoc */
+  protected async update<S extends T>(
+    entity: PartialEntityWithId<S>,
+    options?: SaveOptions,
+  ): Promise<S> {
+    return await runInTransaction(
+      async (session: ClientSession) =>
+        await super.update(entity, {
+          userId: options?.userId,
+          session: options?.session ?? session,
+        }),
       { connection: this.connection },
     );
   }


### PR DESCRIPTION
## What is the purpose of this pull request? 
Put an "X" next to item:

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

## What changes did you make?
Added an atomic version of the `update` operation. `MongooseRepository.update` is not atomic, as it requires to first fetch a document matching a given `id` before making the pertaining modifications and then saving it back to the database. This PR includes an overridden version of the `update` operation in `MongooseTransactionalRepository` that wraps `MongooseRepository.update` in a transaction, thus making this operation atomic.

This change required the change of `MongooseRepository.update` visibility to `protected`. This requirement was also an opportunity to make this operation as well as `insert` available to other database operations included in repositories that extend `MongooseRepository`, including custom repositories created by developers using `monguito`. Also for this purpose, we updated the return types of both `insert` and `update` to be a persistable entity (sub)type instead of Mongoose's `HydratedDocument`, hence hiding this implementation detail from developers.

## Which issue (if any) does this pull request address?

## Is there anything you'd like reviewers to focus on?
