### PR TITLE
Support abstract supertype for custom repository type map definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monguito",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "MongoDB Abstract Repository implementation for Node.js",
   "author": {
     "name": "Josu Martinez",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,4 @@
-import {
-  Constructor,
-  MongooseRepository,
-  TypeData,
-  TypeMap,
-} from './mongoose.repository';
+import { MongooseRepository } from './mongoose.repository';
 import { MongooseTransactionalRepository } from './mongoose.transactional-repository';
 import { PartialEntityWithId, Repository } from './repository';
 import { TransactionalRepository } from './transactional-repository';
@@ -21,6 +16,7 @@ import {
   SearchOptions,
 } from './util/operation-options';
 import { AuditableSchema, BaseSchema, extendSchema } from './util/schema';
+import { Constructor, TypeData, TypeMap } from './util/type-map';
 
 export {
   Auditable,

--- a/src/mongoose.repository.ts
+++ b/src/mongoose.repository.ts
@@ -22,10 +22,15 @@ import { SaveOptions, SearchOptions } from './util/operation-options';
 export type Constructor<T extends Entity> = new (...args: any) => T;
 
 /**
+ * Models an abstract domain root object instance constructor.
+ */
+export type AbsConstructor<T extends Entity> = abstract new (...args: any) => T;
+
+/**
  * Models some domain object type data.
  */
 export type TypeData<T extends Entity> = {
-  type: Constructor<T>;
+  type: Constructor<T> | AbsConstructor<T>;
   schema: Schema;
 };
 
@@ -193,6 +198,7 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
     const entityKey = document.get('__t') ?? 'Default';
     const constructor = this.typeMap.get(entityKey)?.type;
     if (constructor) {
+      // @ts-expect-error - safe as no abstract class instance can be stored in the first place
       return new constructor(document.toObject()) as S;
     }
     throw new UndefinedConstructorException(

--- a/src/mongoose.transactional-repository.ts
+++ b/src/mongoose.transactional-repository.ts
@@ -1,5 +1,5 @@
 import { ClientSession, Connection, UpdateQuery } from 'mongoose';
-import { MongooseRepository, TypeMap } from './mongoose.repository';
+import { MongooseRepository } from './mongoose.repository';
 import { PartialEntityWithId } from './repository';
 import { TransactionalRepository } from './transactional-repository';
 import { Entity } from './util/entity';
@@ -10,6 +10,7 @@ import {
   SaveOptions,
 } from './util/operation-options';
 import { runInTransaction } from './util/transaction';
+import { TypeMap } from './util/type-map';
 
 /**
  * Abstract Mongoose-based implementation of the {@link TransactionalRepository} interface.

--- a/src/util/type-map.ts
+++ b/src/util/type-map.ts
@@ -1,0 +1,93 @@
+import { Schema } from 'mongoose';
+import { Entity } from './entity';
+import { IllegalArgumentException } from './exceptions';
+
+/**
+ * Models a domain object instance constructor.
+ */
+export type Constructor<T> = new (...args: any) => T;
+
+/**
+ * Models an abstract domain object supertype instance constructor.
+ */
+
+export type AbsConstructor<T> = abstract new (...args: any) => T;
+
+/**
+ * Models some domain object subtype data.
+ */
+export type TypeData<T> = {
+  type: Constructor<T>;
+  schema: Schema;
+};
+
+/**
+ * Models some domain object supertype data.
+ */
+export type SupertypeData<T> = {
+  type: Constructor<T> | AbsConstructor<T>;
+  schema: Schema;
+};
+
+/**
+ * Models a map of domain object subtypes.
+ */
+export type SubtypeMap<T> = {
+  [key: string]: TypeData<T extends infer U ? U : never>;
+};
+
+/**
+ * Models a map of domain object supertype and subtypes.
+ */
+export type TypeMap<T extends Entity> =
+  | {
+      ['Default']: SupertypeData<T>;
+    }
+  | SubtypeMap<T>;
+
+/**
+ * A `TypeMap` implementation designed to ease map content handling for its clients.
+ */
+export class TypeMapImpl<T extends Entity> {
+  readonly types: string[];
+  readonly default: SupertypeData<T>;
+  readonly data: TypeData<T>[];
+
+  constructor(map: TypeMap<T>) {
+    if (!map.Default) {
+      throw new IllegalArgumentException(
+        'The given map must include domain supertype data',
+      );
+    }
+    this.default = map.Default as SupertypeData<T>;
+    this.types = Object.keys(map).filter((key) => key !== 'Default');
+    this.data = Object.entries(map).reduce((accumulator, entry) => {
+      if (entry[0] !== 'Default') {
+        // @ts-expect-error - safe instantiation as any non-root map entry refers to some subtype data
+        accumulator.push(entry[1]);
+      }
+      return accumulator;
+    }, []);
+  }
+
+  getSubtypeData(type: string): TypeData<T> | undefined {
+    const index = this.types.indexOf(type);
+    return index !== -1 ? this.data[index] : undefined;
+  }
+
+  getSupertypeData(): TypeData<T> | SupertypeData<T> {
+    return this.default;
+  }
+
+  getSupertypeName(): string {
+    return this.getSupertypeData().type.name;
+  }
+
+  getSubtypesData(): TypeData<T>[] {
+    return this.data;
+  }
+
+  has(type: string): boolean {
+    return type === this.getSupertypeName() || this.types.indexOf(type) !== -1;
+  }
+}


### PR DESCRIPTION
## What is the purpose of this pull request? 
Put an "X" next to item:

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

## What changes did you make? 
Custom repository developers can now specify an abstract class as the root (i.e., `default`) type of the persistable domain model. Also, I re-designed part of the type system to enable better IDE support.

## Which issue (if any) does this pull request address?

## Is there anything you'd like reviewers to focus on?
