### PR TITLE
feat: add extra options to findOne operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ interface Repository<T extends Entity> {
     options?: FindByIdOptions,
   ) => Promise<Optional<S>>;
   findOne: <S extends T>(
-    filters: any,
+    filters: any, // Deprecated since v5.0.1, use options.filters instead
     options?: FindOneOptions,
   ) => Promise<Optional<S>>;
   findAll: <S extends T>(options?: FindAllOptions) => Promise<S[]>;
@@ -208,7 +208,7 @@ export interface TransactionalRepository<T extends Entity>
 ```
 
 > [!NOTE]
-> To ensure operation atomicity you must use a MongoDB cluster (e.g., a replica set) and make your custom repository extend `MongooseTransactionalRepository`. All the inherited default CRUD operations (i.e., the operations specified at `Repository` and `TransactionalRepository`) will be then guranteed to be atomic when a client of your custom repository invokes them. If you want to add a custom atomic operation that composes any other default or custom operation to your repository, then use the [`runInTransaction`](#custom-transactional-operations) utility function. You can check the [soft deleteAll function](examples/nestjs-mongoose-book-manager/README.md#book-repository) as a custom atomic composite operation implementation example.
+> To ensure operation atomicity you must use a MongoDB cluster (e.g., a replica set) and make your custom repository extend `MongooseTransactionalRepository`. All the inherited default CRUD operations (i.e., the operations specified at `Repository` and `TransactionalRepository`) will be then guranteed to be atomic when a client of your custom repository invokes them. If you want to add a custom atomic operation that composes any other default or custom operation to your repository, then use the [`runInTransaction`](#custom-transactional-operations) utility function. You may check a soft deletion-based version of `deleteAll` [here](examples/nestjs-mongoose-book-manager/README.md/#book-repository) as a custom atomic composite operation implementation example.
 
 ### `saveAll`
 
@@ -409,7 +409,7 @@ Mongoose provides the means to write database operations that are to run in a tr
 
 This is a pretty cumbersome procedure to follow. `monguito` includes `runInTransaction`, a function that removes this procedural boilerplate and lets you focus on defining your transactional operations. This function receives a `callback` function representing your custom transactional operation and some transactional `options` parameter. You can use this parameter to specify a MongoDB `connection` to create a new transaction session from, or a reference to a transaction `session`, useful when you want to run your custom operation within an already existent session.
 
-As an example of a custom transactional operation, you may see an overriden version of `deleteAll` that performs soft deletion of entities [here](examples/nestjs-mongoose-book-manager/README.md/#book-repository).
+You may check a soft deletion-based version of `deleteAll` [here](examples/nestjs-mongoose-book-manager/README.md/#book-repository) as a custom atomic operation implementation example.
 
 # Comparison to other Alternatives
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ interface Repository<T extends Entity> {
     id: string,
     options?: FindByIdOptions,
   ) => Promise<Optional<S>>;
-  findOne: <S extends T>(filters: any) => Promise<Optional<S>>;
+  findOne: <S extends T>(
+    filters: any,
+    options?: FindOneOptions,
+  ) => Promise<Optional<S>>;
   findAll: <S extends T>(options?: FindAllOptions) => Promise<S[]>;
   save: <S extends T>(
     entity: S | PartialEntityWithId<S>,

--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ object type (e.g., `PaperBook` or `AudioBook`). This way, you can be sure that t
 are of the type you expect.
 
 > [!NOTE]
-> Keep in mind that the current semantics for these operations are those provided at `MongooseRepository`; if you want any of these operations to behave differently then you must override it at your custom repository implementation.
+> Keep in mind that the current semantics for these operations are those provided at `MongooseRepository`. If you want any of these operations to behave differently then you must override it at your custom repository implementation.
+
+> [!NOTE]
+> All CRUD operations include an `options` parameter as part of their signature. This parameter specifies some optional configuration options. There are two types of options: _behavioural_ and _transactional_. The former dictate the behaviour of the operation, thus influencing the operation result, while the later are required to execute the operation within a MongoDB transaction. You may read more about transactional options in the [following section](#transactional-crud-operations). This section focuses on behavioural options only.
 
 ### `findById`
 
@@ -160,11 +163,16 @@ This value wraps an actual entity or `null` in case that no entity matches the g
 
 Returns an [`Optional`](https://github.com/bromne/typescript-optional#readme) entity matching the given `filters` parameter values. In case there are more than one matching entities, `findOne` returns the first entity satisfying the condition. The result value wraps an actual entity or `null` in case that no entity matches the given conditions.
 
+> [!WARNING]
+> Since v5.0.1 the `filters` parameter is now deprecated. Use the new behavioural `options.filters` option instead.
+
 ### `findAll`
 
-Returns an array including all the persisted entities, or an empty array otherwise. This operation accepts some extra search `options`:
+Returns an array including all the persisted entities, or an empty array otherwise.
 
-- `filters`: a [MongoDB query](https://www.mongodb.com/docs/manual/tutorial/query-documents/) to filter results
+This operation accepts some optional behavioural options:
+
+- `filters`: a [MongoDB search criteria](https://www.mongodb.com/docs/manual/tutorial/query-documents/) to filter results
 - `sortBy`: a [MongoDB sort criteria](https://www.mongodb.com/docs/manual/reference/method/cursor.sort/#mongodb-method-cursor.sort)
   to return results in some sorted order
 - `pageable`: pagination data (i.e., `pageNumber` and `offset`) required to return a particular set of results.
@@ -172,14 +180,12 @@ Returns an array including all the persisted entities, or an empty array otherwi
 
 ### `save`
 
+Persists the given entity by either inserting or updating it and returns the persisted entity. If the entity specifies an `id` field, this function updates it, unless it does not exist in the pertaining collection, in which case this operation results in an exception being thrown. Otherwise, if the entity does not specify an `id` field, it inserts it into the collection. Beware that trying to persist a new entity that includes a developer specified `id` is considered a _system invariant violation_; only Mongoose is able to produce MongoDB identifiers to prevent `id` collisions and undesired entity updates.
+
+This operation accepts `userId` as an optional behavioural option to enable user audit data handling (read [this section](#built-in-audit-data-support) for further details on this topic).
+
 > [!WARNING]
 > The version of `save` specified at `MongooseRepository` is not [atomic](#supported-database-operations). If you are to execute it in a concurrent environment, make sure that your custom repository extends `MongooseTransactionalRepository` instead.
-
-Persists the given entity by either inserting or updating it and returns the persisted entity. If the entity specifies an `id` field, this function updates it, unless it does not exist in the pertaining collection, in which case this operation results in an exception being thrown. Otherwise, if the entity does not specify an `id` field, it inserts it into the collection.
-
-Beware that trying to persist a new entity that includes a developer specified `id` is considered a _system invariant violation_; only Mongoose is able to produce MongoDB identifiers to prevent `id` collisions and undesired entity updates.
-
-This operation accepts `userId` as an extra `options` parameter to enable user audit data handling (read [this section](#built-in-audit-data-support) for further details on this topic).
 
 ### `deleteById`
 
@@ -201,22 +207,18 @@ export interface TransactionalRepository<T extends Entity>
 }
 ```
 
-> [!WARNING]
-> The following operations are only guaranteed to be atomic when executed on a MongoDB cluster.
+> [!NOTE]
+> To ensure operation atomicity you must use a MongoDB cluster (e.g., a replica set) and make your custom repository extend `MongooseTransactionalRepository`. All the inherited default CRUD operations (i.e., the operations specified at `Repository` and `TransactionalRepository`) will be then guranteed to be atomic when a client of your custom repository invokes them. If you want to add a custom atomic operation that composes any other default or custom operation to your repository, then use the [`runInTransaction`](#custom-transactional-operations) utility function. You can check the [soft deleteAll function](examples/nestjs-mongoose-book-manager/README.md#book-repository) as a custom atomic composite operation implementation example.
 
 ### `saveAll`
 
-Persists the given list of entities by either inserting or updating them and returns the list of persisted entities. As with the `save` operation, `saveAll` inserts or updates each entity of the list based on the existence of the `id` field.
+Persists the given list of entities by either inserting or updating them and returns the list of persisted entities. As with the `save` operation, `saveAll` inserts or updates each entity of the list based on the existence of the `id` field. In the event of any error, this operation rollbacks all its changes. In other words, it does not save any given entity, thus guaranteeing operation atomicity.
 
-In the event of any error, this operation rollbacks all its changes. In other words, it does not save any given entity, thus guaranteeing operation atomicity.
-
-This operation accepts `userId` as an extra `options` parameter to enable user audit data handling (read [this section](#built-in-audit-data-support) for further details on this topic).
+This operation accepts `userId` as an optional behavioural option to enable user audit data handling (read [this section](#built-in-audit-data-support) for further details on this topic).
 
 ### `deleteAll`
 
-Deletes all the entities that match the MongoDB `filters` query specified within the `options` parameter. This operation returns the total amount of deleted entities.
-
-In the event of any error, this operation rollbacks all its changes. In other words, it does not delete any entity, thus guaranteeing operation atomicity.
+Deletes all the entities that match the MongoDB a given search criteria specified as `options.filters` behavioural option and returns the total amount of deleted entities. Beware that if no search criteria is provided, then `deleteAll` deletes all the stored entities. In the event of any error, this operation rollbacks all its changes. In other words, it does not delete any stored entity, thus guaranteeing operation atomicity.
 
 # Examples
 

--- a/examples/nestjs-mongoose-book-manager/README.md
+++ b/examples/nestjs-mongoose-book-manager/README.md
@@ -127,7 +127,9 @@ export class MongooseBookRepository
 
   async deleteAll(options?: SoftDeleteAllOptions): Promise<number> {
     if (options?.filters === null) {
-      throw new IllegalArgumentException('The given filters must be valid');
+      throw new IllegalArgumentException(
+        'The given search criteria (filters) cannot be null',
+      );
     }
     return await runInTransaction(
       async (session: ClientSession) => {

--- a/examples/nestjs-mongoose-book-manager/src/book.repository.ts
+++ b/examples/nestjs-mongoose-book-manager/src/book.repository.ts
@@ -46,7 +46,9 @@ export class MongooseBookRepository
 
   async deleteAll(options?: SoftDeleteAllOptions): Promise<number> {
     if (options?.filters === null) {
-      throw new IllegalArgumentException('The given filters must be valid');
+      throw new IllegalArgumentException(
+        'The given search criteria (filters) cannot be null',
+      );
     }
     return await runInTransaction(
       async (session: ClientSession) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monguito",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "MongoDB Abstract Repository implementation for Node.js",
   "author": {
     "name": "Josu Martinez",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   DeleteByIdOptions,
   FindAllOptions,
   FindByIdOptions,
+  FindOneOptions,
   SaveAllOptions,
   SaveOptions,
 } from './util/operation-options';
@@ -40,6 +41,7 @@ export {
   Entity,
   FindAllOptions,
   FindByIdOptions,
+  FindOneOptions,
   IllegalArgumentException,
   MongooseRepository,
   MongooseTransactionalRepository,

--- a/src/mongoose.repository.ts
+++ b/src/mongoose.repository.ts
@@ -103,10 +103,15 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
     filters: any,
     options?: FindOneOptions,
   ): Promise<Optional<S>> {
-    if (!filters)
-      throw new IllegalArgumentException('The given filters must be valid');
+    if (!filters && !options?.filters)
+      throw new IllegalArgumentException('Missing search criteria (filters)');
+    if (filters) {
+      console.warn(
+        'Since v5.0.1, the "filters" parameter is deprecated. Use options.filters instead.',
+      );
+    }
     const document = await this.entityModel
-      .findOne(filters)
+      .findOne(options?.filters ?? filters)
       .session(options?.session ?? null)
       .exec();
     return Optional.ofNullable(this.instantiateFrom(document) as S);

--- a/src/mongoose.repository.ts
+++ b/src/mongoose.repository.ts
@@ -34,7 +34,7 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
   /**
    * Sets up the underlying configuration to enable database operation execution.
    * @param {TypeMap<T>} typeMap a map of domain object types supported by this repository.
-   * @param {Connection=} connection (optional) a connection to an instance of MongoDB.
+   * @param {Connection=} connection (optional) a MongoDB instance connection.
    */
   protected constructor(
     typeMap: TypeMap<T>,
@@ -46,6 +46,10 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
 
   /** @inheritdoc */
   async deleteById(id: string, options?: DeleteByIdOptions): Promise<boolean> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
     if (!id) throw new IllegalArgumentException('The given ID must be valid');
     const isDeleted = await this.entityModel.findByIdAndDelete(id, {
       session: options?.session,
@@ -55,6 +59,10 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
 
   /** @inheritdoc */
   async findAll<S extends T>(options?: FindAllOptions): Promise<S[]> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
     if (options?.pageable?.pageNumber && options?.pageable?.pageNumber < 0) {
       throw new IllegalArgumentException(
         'The given page number must be a positive number',
@@ -90,6 +98,10 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
     id: string,
     options?: FindByIdOptions,
   ): Promise<Optional<S>> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
     if (!id) throw new IllegalArgumentException('The given ID must be valid');
     const document = await this.entityModel
       .findById(id)
@@ -103,13 +115,16 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
     filters: any,
     options?: FindOneOptions,
   ): Promise<Optional<S>> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
+    if (filters)
+      console.warn(
+        'Since v5.0.1 the "filters" parameter is deprecated. Use "options.filters" instead.',
+      );
     if (!filters && !options?.filters)
       throw new IllegalArgumentException('Missing search criteria (filters)');
-    if (filters) {
-      console.warn(
-        'Since v5.0.1, the "filters" parameter is deprecated. Use options.filters instead.',
-      );
-    }
     const document = await this.entityModel
       .findOne(options?.filters ?? filters)
       .session(options?.session ?? null)
@@ -122,6 +137,10 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
     entity: S | PartialEntityWithId<S>,
     options?: SaveOptions,
   ): Promise<S> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
     if (!entity)
       throw new IllegalArgumentException('The given entity must be valid');
     try {
@@ -198,6 +217,10 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
     entity: S,
     options?: SaveOptions,
   ): Promise<S> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
     if (!entity)
       throw new IllegalArgumentException('The given entity must be valid');
     const entityClassName = entity['constructor']['name'];
@@ -245,6 +268,10 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
     entity: PartialEntityWithId<S>,
     options?: SaveOptions,
   ): Promise<S> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
     if (!entity)
       throw new IllegalArgumentException('The given entity must be valid');
     const document = await this.entityModel

--- a/src/mongoose.repository.ts
+++ b/src/mongoose.repository.ts
@@ -17,6 +17,7 @@ import {
   DeleteByIdOptions,
   FindAllOptions,
   FindByIdOptions,
+  FindOneOptions,
   SaveOptions,
 } from './util/operation-options';
 import { Constructor, TypeMap, TypeMapImpl } from './util/type-map';
@@ -98,10 +99,16 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
   }
 
   /** @inheritdoc */
-  async findOne<S extends T>(filters: any): Promise<Optional<S>> {
+  async findOne<S extends T>(
+    filters: any,
+    options?: FindOneOptions,
+  ): Promise<Optional<S>> {
     if (!filters)
       throw new IllegalArgumentException('The given filters must be valid');
-    const document = await this.entityModel.findOne(filters).exec();
+    const document = await this.entityModel
+      .findOne(filters)
+      .session(options?.session ?? null)
+      .exec();
     return Optional.ofNullable(this.instantiateFrom(document) as S);
   }
 

--- a/src/mongoose.transactional-repository.ts
+++ b/src/mongoose.transactional-repository.ts
@@ -24,7 +24,7 @@ export abstract class MongooseTransactionalRepository<
   /**
    * Sets up the underlying configuration to enable database operation execution.
    * @param {TypeMap<T>} typeMap a map of domain object types supported by this repository.
-   * @param {Connection=} connection (optional) a connection to an instance of MongoDB.
+   * @param {Connection=} connection (optional) a MongoDB instance connection.
    */
   protected constructor(typeMap: TypeMap<T>, connection?: Connection) {
     super(typeMap, connection);
@@ -35,6 +35,10 @@ export abstract class MongooseTransactionalRepository<
     entities: (S | PartialEntityWithId<S>)[],
     options?: SaveAllOptions,
   ): Promise<S[]> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
     return await runInTransaction(
       async (session: ClientSession) =>
         await Promise.all(
@@ -52,6 +56,10 @@ export abstract class MongooseTransactionalRepository<
 
   /** @inheritdoc */
   async deleteAll(options?: DeleteAllOptions): Promise<number> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
     if (options?.filters === null) {
       throw new IllegalArgumentException('Null filters are disallowed');
     }
@@ -68,6 +76,10 @@ export abstract class MongooseTransactionalRepository<
     entity: PartialEntityWithId<S>,
     options?: SaveOptions,
   ): Promise<S> {
+    if (options?.connection)
+      console.warn(
+        'Since v5.0.1 "options.connection" is deprecated as is of no longer use.',
+      );
     const updateOperation = super.update.bind(this);
     return await runInTransaction(
       async (session: ClientSession) =>

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -35,8 +35,7 @@ export interface Repository<T extends Entity> {
 
   /**
    * Finds an entity by some filters.
-   * @param {any} filters some filters for the search.
-   * @deprecated Since v5.0.1, use options.filters instead.
+   * @param {any} filters some filters for the search - Deprecated since v5.0.1, use options.filters instead.
    * @param {FindOneOptions=} options (optional) search operation options.
    * @returns {Promise<Optional<S>>} the entity or null.
    * @throws {IllegalArgumentException} if the given `filters` parameter is `undefined` or `null`.

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -4,6 +4,7 @@ import {
   DeleteByIdOptions,
   FindAllOptions,
   FindByIdOptions,
+  FindOneOptions,
   SaveOptions,
 } from './util/operation-options';
 
@@ -35,10 +36,14 @@ export interface Repository<T extends Entity> {
   /**
    * Finds an entity by some filters.
    * @param {any} filters some filters for the search.
+   * @param {FindOneOptions=} options (optional) search operation options.
    * @returns {Promise<Optional<S>>} the entity or null.
    * @throws {IllegalArgumentException} if the given `filters` parameter is `undefined` or `null`.
    */
-  findOne: <S extends T>(filters: any) => Promise<Optional<S>>;
+  findOne: <S extends T>(
+    filters: any,
+    options?: FindOneOptions,
+  ) => Promise<Optional<S>>;
 
   /**
    * Finds all entities.

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -36,6 +36,7 @@ export interface Repository<T extends Entity> {
   /**
    * Finds an entity by some filters.
    * @param {any} filters some filters for the search.
+   * @deprecated Since v5.0.1, use options.filters instead.
    * @param {FindOneOptions=} options (optional) search operation options.
    * @returns {Promise<Optional<S>>} the entity or null.
    * @throws {IllegalArgumentException} if the given `filters` parameter is `undefined` or `null`.

--- a/src/util/operation-options.ts
+++ b/src/util/operation-options.ts
@@ -62,6 +62,11 @@ export type FindAllOptions = {
 export type FindByIdOptions = TransactionOptions;
 
 /**
+ * Specifies options for the `findOne` operation;
+ */
+export type FindOneOptions = TransactionOptions;
+
+/**
  * Specifies options for the `save` operation.
  */
 export type SaveOptions = AuditOptions & TransactionOptions;

--- a/src/util/operation-options.ts
+++ b/src/util/operation-options.ts
@@ -64,7 +64,9 @@ export type FindByIdOptions = TransactionOptions;
 /**
  * Specifies options for the `findOne` operation;
  */
-export type FindOneOptions = TransactionOptions;
+export type FindOneOptions = {
+  filters?: any;
+} & TransactionOptions;
 
 /**
  * Specifies options for the `save` operation.


### PR DESCRIPTION
## What is the purpose of this pull request? 
Put an "X" next to item:

[x] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

## What changes did you make? 
Added `options` parameter of new `FindOneOptions` type to the `findOne` operation in order to make it available in the implementation of custom atomic operations. 

Also added two deprecation warnings:
- The `filters` parameter in `findOne` has been deprecated in favour of `FindOneOptions.filters`
- The `options.connection` property of all operation options types has been deprecated as it is of no longer use

Finally, improved basic and transactional CRUD operations documentation.

## Which issue (if any) does this pull request address?

## Is there anything you'd like reviewers to focus on?
