### PR TITLE
Add validation errors to validation exception cause

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         node-version: [22.x, 23.x]
     steps:
       - name: Checkout Code 🛎️

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monguito",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "MongoDB Abstract Repository implementation for Node.js",
   "author": "Josu Martinez <josu.martinez@gmail.com>",
   "license": "MIT",

--- a/src/mongoose.repository.ts
+++ b/src/mongoose.repository.ts
@@ -136,16 +136,12 @@ export abstract class MongooseRepository<T extends Entity & UpdateQuery<T>>
         return await this.update(entity as PartialEntityWithId<S>, options);
       }
     } catch (error) {
-      if (
-        error.message.includes('validation failed') ||
-        error.message.includes('duplicate key error')
-      ) {
+      if (error instanceof mongoose.Error.ValidationError) {
         throw new ValidationException(
           'One or more fields of the given entity do not specify valid values',
           error,
         );
-      }
-      throw error;
+      } else throw error;
     }
   }
 

--- a/src/util/exceptions.ts
+++ b/src/util/exceptions.ts
@@ -1,3 +1,5 @@
+import mongoose from 'mongoose';
+
 abstract class Exception extends Error {
   constructor(message: string, cause?: Error) {
     super(message, { cause });
@@ -38,14 +40,54 @@ export class UndefinedConstructorException extends Exception {
 
 /**
  * Models a persistable domain object schema validation rule violation exception.
+ * Since there may be several properties of the persistable domain object that are invalid,
+ * this exception provides means to retrieve the invalid fields altogeher of by kind.
  */
 export class ValidationException extends Exception {
+  override cause: mongoose.Error.ValidationError;
+
   /**
    * Creates an `ValidationException`, optionally wrapping an error.
    * @param {string} message the message of the exception.
    * @param {Error} cause (optional) the wrapped error.
    */
-  constructor(message: string, cause?: Error) {
+  constructor(message: string, cause: mongoose.Error.ValidationError) {
     super(message, cause);
+    this.cause = cause;
+  }
+
+  /**
+   * Retrieves all the invalid field names of the persistable domain object.
+   * @returns an array with the names of the invalid fields.
+   */
+  getInvalidFields(): string[] {
+    return Object.keys(this.cause.errors);
+  }
+
+  /**
+   * Retrieves all the non-specified required field names of the persistable domain object.
+   * @returns an array with the names of the required fields that are not specified.
+   */
+  getRequiredFields(): string[] {
+    return this.getInvalidFieldsOfKind('required');
+  }
+
+  /**
+   * Retrieves all the duplicated unique field names of the persistable domain object.
+   * @returns an array with the names of the unique fields that are duplicated.
+   */
+  getUniqueFields(): string[] {
+    return this.getInvalidFieldsOfKind('unique');
+  }
+
+  private getInvalidFieldsOfKind(kind: string): string[] {
+    const invalidFields: string[] = [];
+    for (const field in this.cause.errors) {
+      const error = this.cause.errors[field];
+      if (error.kind === kind) {
+        invalidFields.push(error.path);
+      }
+    }
+    return invalidFields;
   }
 }


### PR DESCRIPTION
## What is the purpose of this pull request? 
Put an "X" next to item:

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

## What changes did you make? 
Any `ValidationException` consumer can now request any exception instance of this type which fields were invalid in general, or more specifically by invalidity kind i.e., the fields that are meant to be required or unique. This is thanks to the new `ValidationException` methods `getInvalidFields`, `getRequiredFields`, and `getUniqueFields`, respectively.

## Which issue (if any) does this pull request address?

## Is there anything you'd like reviewers to focus on?
