### PR TITLE
fix: rename validation exception functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monguito",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "MongoDB Abstract Repository implementation for Node.js",
   "author": "Josu Martinez <josu.martinez@gmail.com>",
   "license": "MIT",

--- a/src/util/exceptions.ts
+++ b/src/util/exceptions.ts
@@ -41,7 +41,7 @@ export class UndefinedConstructorException extends Exception {
 /**
  * Models a persistable domain object schema validation rule violation exception.
  * Since there may be several properties of the persistable domain object that are invalid,
- * this exception provides means to retrieve the invalid fields altogeher of by kind.
+ * this exception provides means to retrieve the invalid fields altogeher or by kind.
  */
 export class ValidationException extends Exception {
   override cause: mongoose.Error.ValidationError;
@@ -68,7 +68,7 @@ export class ValidationException extends Exception {
    * Retrieves all the non-specified required field names of the persistable domain object.
    * @returns an array with the names of the required fields that are not specified.
    */
-  getRequiredFields(): string[] {
+  getInvalidRequiredFields(): string[] {
     return this.getInvalidFieldsOfKind('required');
   }
 
@@ -76,7 +76,7 @@ export class ValidationException extends Exception {
    * Retrieves all the duplicated unique field names of the persistable domain object.
    * @returns an array with the names of the unique fields that are duplicated.
    */
-  getUniqueFields(): string[] {
+  getInvalidUniqueFields(): string[] {
     return this.getInvalidFieldsOfKind('unique');
   }
 

--- a/test/repository/book.repository.test.ts
+++ b/test/repository/book.repository.test.ts
@@ -1041,9 +1041,9 @@ describe('Given an instance of book repository', () => {
                   await bookRepository.save(bookToInsert);
                 } catch (error) {
                   expect(error).toBeInstanceOf(ValidationException);
-                  expect(error.getRequiredFields()).toEqual(['title']);
-                  expect(error.getUniqueFields()).toEqual(['isbn']);
                   expect(error.getInvalidFields()).toEqual(['title', 'isbn']);
+                  expect(error.getInvalidRequiredFields()).toEqual(['title']);
+                  expect(error.getInvalidUniqueFields()).toEqual(['isbn']);
                 }
               });
             });
@@ -1091,9 +1091,9 @@ describe('Given an instance of book repository', () => {
                 await bookRepository.save(bookToInsert);
               } catch (error) {
                 expect(error).toBeInstanceOf(ValidationException);
-                expect(error.getRequiredFields()).toEqual([]);
-                expect(error.getUniqueFields()).toEqual(['isbn']);
                 expect(error.getInvalidFields()).toEqual(['isbn']);
+                expect(error.getInvalidRequiredFields()).toEqual([]);
+                expect(error.getInvalidUniqueFields()).toEqual(['isbn']);
               }
             });
           });


### PR DESCRIPTION
## What is the purpose of this pull request? 
Put an "X" next to item:

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other

## What changes did you make? 
Developers may find the current names of `ValidationException` invalid field extraction functions a bit confusing. Added "invalid" in their names to improve readability e.g., `getRequiredFields` is now `getInvalidRequiredFields`.

## Which issue (if any) does this pull request address?

## Is there anything you'd like reviewers to focus on?
